### PR TITLE
Update Fetch NPM Package Info Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,10 @@
 ## Fetch NPM Package Info Command
 
 This command allows users to fetch information about an NPM package, including its latest version, description, and author. It utilizes the npm registry API to retrieve package details. Users can input a package name to fetch its information.
+
+### Command Interactions as depicted in the screenshots
+
+The command provides an input field for users to enter the name of the NPM package they wish to inquire about. Upon submission, it fetches and displays the package's latest version, description, and author information.
+
+![Command UI](https://github.com/atian25/raycast-test/assets/screenshot1.png)
+![Command Interactions](https://github.com/atian25/raycast-test/assets/screenshot2.png)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import { Detail, useFetch } from "@raycast/api";
+import { Detail, useFetch, ActionPanel, Action, Form, showToast, ToastStyle } from "@raycast/api";
 import { useState } from "react";
 
 export default function Command() {
@@ -8,9 +8,13 @@ export default function Command() {
     headers: {
       Accept: "application/json",
     },
-  });
+    keepalive: true,
+  }, [packageName]);
 
-  if (error) return <Detail markdown="## Error fetching package info" />;
+  if (error) {
+    showToast(ToastStyle.Failure, "Failed to fetch package info", error.toString());
+    return <Detail markdown="## Error fetching package info" />;
+  }
   if (isLoading) return <Detail markdown="## Loading..." />;
 
   const packageInfo = data ? (
@@ -20,10 +24,24 @@ export default function Command() {
 - **Latest Version:** ${data["dist-tags"].latest}
 - **Description:** ${data.description}
 - **Author:** ${data.author ? data.author.name : "N/A"}
+- **License:** ${data.license ? data.license : "N/A"}
+- **Homepage:** [${data.homepage}](${data.homepage})
 `}
+      actions={
+        <ActionPanel>
+          <Action.OpenInBrowser url={`https://www.npmjs.com/package/${packageName}`} />
+        </ActionPanel>
+      }
     />
   ) : (
-    <Detail markdown="## Please enter a package name" />
+    <Form
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Fetch Package Info" onSubmit={(values) => setPackageName(values.packageName)} />
+        </ActionPanel>
+      }>
+      <Form.TextField id="packageName" title="Package Name" placeholder="Enter NPM package name" />
+    </Form>
   );
 
   return packageInfo;


### PR DESCRIPTION
Related to #6

Updates the Fetch NPM Package Info Command to enhance user interaction and display additional package details as depicted in the provided screenshots.

- Implements an input field allowing users to enter the name of the NPM package they wish to inquire about, enhancing user interaction.
- Updates the `src/index.tsx` file to fetch and display additional package information, including the license and homepage URL, aligning with the details shown in the screenshots.
- Introduces error handling with meaningful messages to the user through toast notifications, improving the user experience in case of fetch failures.
- Adds an action to open the NPM package page in the browser directly from the Raycast command, providing a seamless navigation experience.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/atian25/raycast-test/issues/6?shareId=990469a9-4166-4818-b71d-e1337855e513).